### PR TITLE
Make (input) file a required option instead of a program argument 

### DIFF
--- a/lib/Program.ts
+++ b/lib/Program.ts
@@ -17,11 +17,11 @@ export default class Program {
     this._command = new Command();
     this._command.version(this._version);
     this._command
-      .argument('<file>', 'file to analyze')
       .option('-b --bulk <bulk>', 'number of concurrent line analysis in parallel')
       .option('-d --delay <delay>', 'delay between two HTTP call')
       .option('-f --from <from>', 'line from')
-      .option('-o --output <output>', 'output file')
+      .requiredOption('-i --input <input_file>', 'file to analyze')
+      .option('-o --output <output_file>', 'output file')
       .option('-s --separator <separator>', 'column separator')
       .option('-t --to <to>', 'line to');
   }
@@ -31,23 +31,21 @@ export default class Program {
 
     const options = this._command.opts();
 
-    const file = this._command.args[0];
-
     logger.info('--------------------------------------------------------------------------------');
     logger.info(`Version: ${this._version}`);
     logger.info('Options:');
-    logger.info(`  - file: ${file}`);
+    logger.info(`  - input file: ${options.input_file}`);
     logger.info(`  - bulk: ${options.bulk}`);
     logger.info(`  - delay: ${options.delay}`);
     logger.info(`  - from: ${options.from}`);
     logger.info(`  - headers: ${options.headers}`);
-    logger.info(`  - output: ${options.output}`);
+    logger.info(`  - output: ${options.output_file}`);
     logger.info(`  - separator: ${options.separator}`);
     logger.info(`  - to: ${options.to}`);
     logger.info();
 
     const parser = new CsvFileParser(options);
-    const lines: Line[] = await parser.parse(file);
+    const lines: Line[] = await parser.parse();
 
     const analyzer = new Analyzer(options);
     const analyzedLines: AnalyzedLine[] = await analyzer.analyze(lines);

--- a/lib/parsing/CsvFileParser.ts
+++ b/lib/parsing/CsvFileParser.ts
@@ -7,17 +7,20 @@ import { createReadStream, PathLike } from 'fs';
 import chalk from 'chalk';
 
 export default class CsvFileParser extends AbstractParser {
+  input: PathLike;
+
   constructor(options: OptionValues) {
     super(options);
+    this.input = options.input_file;
   }
 
-  extractLines(file: PathLike): Promise<Line[]> {
+  extractLines(): Promise<Line[]> {
     return new Promise<Line[]>((resolve) => {
       let index = 1;
       const lines: Line[] = [];
 
       const rl = readline.createInterface({
-        input: createReadStream(file)
+        input: createReadStream(this.input)
       });
 
       rl.on('line', (rawLine) => {

--- a/lib/parsing/Parser.ts
+++ b/lib/parsing/Parser.ts
@@ -1,5 +1,4 @@
 import { OptionValues } from 'commander';
-import { PathLike } from 'fs';
 import Line from './Line';
 import { logger } from '../tools/Logger';
 
@@ -21,12 +20,11 @@ export abstract class AbstractParser implements Parser {
     this.to = options.to;
   }
 
-  protected abstract extractLines(file: PathLike): Promise<Line[]>;
+  protected abstract extractLines(): Promise<Line[]>;
 
-  async parse(file: PathLike): Promise<Line[]> {
+  async parse(): Promise<Line[]> {
     logger.info('--------------------------------------------------------------------------------');
     logger.info('Phase: "Parsing"');
-    logger.info(` - file: ${file}`);
     logger.info(` - from: ${this.from}`);
     logger.info(` - separator: ${this.separator}`);
     logger.info(` - to: ${this.to}`);
@@ -34,7 +32,7 @@ export abstract class AbstractParser implements Parser {
 
     const hrStart: [number, number] = process.hrtime();
 
-    const lines = await this.extractLines(file);
+    const lines = await this.extractLines();
 
     logger.info();
     const hrEnd: [number, number] = process.hrtime(hrStart);

--- a/lib/reporting/CsvFileReporter.ts
+++ b/lib/reporting/CsvFileReporter.ts
@@ -9,7 +9,7 @@ export default class CsvFileReporter extends AbstractReporter {
 
   constructor(options: OptionValues) {
     super(options);
-    this.output = options.output;
+    this.output = options.output_file;
   }
 
   writeOutputLines(analyzedLines: AnalyzedLine[]): Promise<void> {

--- a/test/parsing/CsvFileParser.test.ts
+++ b/test/parsing/CsvFileParser.test.ts
@@ -30,10 +30,10 @@ describe('#parse', () => {
 
   test('should return as many Line objects as file lines', async () => {
     // given
-    const parser = new CsvFileParser({});
+    const parser = new CsvFileParser({ input_file: `${__dirname}/test_simple.csv.fixture` });
 
     // when
-    const lines: Line[] = await parser.parse(`${__dirname}/test_simple.csv.fixture`);
+    const lines: Line[] = await parser.parse();
 
     // then
     expect(lines.length).toBe(5);
@@ -41,10 +41,10 @@ describe('#parse', () => {
 
   test('should ignore blank or empty lines', async () => {
     // given
-    const parser = new CsvFileParser({});
+    const parser = new CsvFileParser({ input_file: `${__dirname}/test_blank_or_empty_lines.csv.fixture` });
 
     // when
-    const lines: Line[] = await parser.parse(`${__dirname}/test_blank_or_empty_lines.csv.fixture`);
+    const lines: Line[] = await parser.parse();
 
     // then
     expect(lines.length).toBe(3);
@@ -52,10 +52,10 @@ describe('#parse', () => {
 
   test('should take into account "--from" option', async () => {
     // given
-    const parser = new CsvFileParser({from: 2});
+    const parser = new CsvFileParser({from: 2, input_file: `${__dirname}/test_simple.csv.fixture`});
 
     // when
-    const lines: Line[] = await parser.parse(`${__dirname}/test_simple.csv.fixture`);
+    const lines: Line[] = await parser.parse();
 
     // then
     expect(lines.length).toBe(4);
@@ -63,10 +63,10 @@ describe('#parse', () => {
 
   test('should take into account "--to" option', async () => {
     // given
-    const parser = new CsvFileParser({from: 3});
+    const parser = new CsvFileParser({from: 3, input_file: `${__dirname}/test_simple.csv.fixture`});
 
     // when
-    const lines: Line[] = await parser.parse(`${__dirname}/test_simple.csv.fixture`);
+    const lines: Line[] = await parser.parse();
 
     // then
     expect(lines.length).toBe(3);
@@ -74,10 +74,10 @@ describe('#parse', () => {
 
   test('should support "--from" and "--to" options simultaneously', async () => {
     // given
-    const parser = new CsvFileParser({from: 3, to: 4});
+    const parser = new CsvFileParser({from: 3, to: 4, input_file: `${__dirname}/test_simple.csv.fixture`});
 
     // when
-    const lines: Line[] = await parser.parse(`${__dirname}/test_simple.csv.fixture`);
+    const lines: Line[] = await parser.parse();
 
     // then
     expect(lines.length).toBe(2);

--- a/test/reporting/CsvFileReporter.test.ts
+++ b/test/reporting/CsvFileReporter.test.ts
@@ -7,7 +7,7 @@ describe('Constructor', () => {
 
   test('should set output', () => {
     // given
-    const options = {output: `test_output.csv`};
+    const options = {output_file: `test_output.csv`};
 
     // when
     const reporter = new CsvFileReporter(options);
@@ -21,8 +21,8 @@ describe('#report', () => {
 
   test('should ', async () => {
     // given
-    const output = `${__dirname}/test_output.csv`;
-    const reporter = new CsvFileReporter({output});
+    const output_file = `${__dirname}/test_output.csv`;
+    const reporter = new CsvFileReporter({output_file});
 
     const line1 = new Line(1, 'ref_1;https://site.com/image-1', ';');
     const analyzedLine1 = new AnalyzedLine(line1);
@@ -42,7 +42,7 @@ describe('#report', () => {
     await reporter.report(analyzedLines);
 
     // then
-    const printedLines: string[] = fs.readFileSync(output).toString().split('\n');
+    const printedLines: string[] = fs.readFileSync(output_file).toString().split('\n');
     expect(printedLines.length).toBe(4);
     expect(printedLines[0]).toBe('ref_1;https://site.com/image-1;OK');
     expect(printedLines[1]).toBe('ref_2;https://site.com/image-2;KO;FORMAT_ERROR;Not an URL');


### PR DESCRIPTION
### Context

With Commander, it is not easy to manage [options taking varying numbers of option-arguments](https://github.com/tj/commander.js/blob/HEAD/docs/options-taking-varying-arguments.md#alternative-use-options-instead-of-command-arguments).

### Engineering

This PR is a first step to allow options such as `-H http_header_1 -H http_header_2 -H …`.

It transforms the argument `<file>` into a _required option_  `--input <input_file>`.

⚠️ This PR introduces breaking change !

```bash
# Before
$ image-url-checker --output output_file.csv input_file.csv

# After
$ image-url-checker --input input_file.csv --output output_file.csv
```