### PR TITLE
Add -H --header option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ tmp
 reports
 *.csv
 build
-test/**/*.test.js
+test/**/*.test.js*
 coverage

--- a/lib/Program.ts
+++ b/lib/Program.ts
@@ -20,6 +20,7 @@ export default class Program {
       .option('-b, --bulk <bulk>', 'number of concurrent line analysis in parallel')
       .option('-d, --delay <delay>', 'delay between two HTTP call')
       .option('-f, --from <from>', 'line from')
+      .option('-H, --headers <headers...>', 'specify HTTP request headers, ex: -H header:1 -H header:2 -H ...')
       .requiredOption('-i, --input <input>', 'input file data to analyze')
       .option('-o, --output <output>', 'output file report to generate')
       .option('-s, --separator <separator>', 'input file data column separator')

--- a/lib/Program.ts
+++ b/lib/Program.ts
@@ -20,9 +20,9 @@ export default class Program {
       .option('-b, --bulk <bulk>', 'number of concurrent line analysis in parallel')
       .option('-d, --delay <delay>', 'delay between two HTTP call')
       .option('-f, --from <from>', 'line from')
-      .requiredOption('-i, --input <input>', 'file to analyze')
-      .option('-o, --output <output>', 'output file')
-      .option('-s, --separator <separator>', 'column separator')
+      .requiredOption('-i, --input <input>', 'input file data to analyze')
+      .option('-o, --output <output>', 'output file report to generate')
+      .option('-s, --separator <separator>', 'input file data column separator')
       .option('-t, --to <to>', 'line to');
   }
 

--- a/lib/analyzing/Analyzer.ts
+++ b/lib/analyzing/Analyzer.ts
@@ -13,12 +13,18 @@ export default class Analyzer {
 
   bulk: number;
   delay?: number;
+  headers?: any;
 
   constructor(options: OptionValues, httpClient?: HttpClient) {
     this._options = options;
-    this._httpClient = httpClient || new HttpClient();
     this.bulk = parseInt(options.bulk) || 10;
     this.delay = options.delay;
+    this.headers = options.headers;
+
+    this._httpClient = httpClient || new HttpClient();
+    if (options.headers) {
+      this._httpClient.headers = options.headers;
+    }
   }
 
   _sleep(ms: number): Promise<void> {
@@ -97,6 +103,7 @@ export default class Analyzer {
     logger.info(`  - lines: ${lines.length}`);
     logger.info(`  - bulk: ${this.bulk}`);
     logger.info(`  - delay: ${this.delay}`);
+    logger.info(`  - headers: ${this.headers}`);
     logger.info();
 
     const hrStart: [number, number] = process.hrtime();

--- a/lib/tools/HttpClient.ts
+++ b/lib/tools/HttpClient.ts
@@ -1,0 +1,26 @@
+import axios from 'axios';
+
+class HttpClient {
+  async head(url: string): Promise<HttpResponse> {
+    const response = await axios.head(url);
+    return new HttpResponse(response);
+  }
+}
+
+class HttpResponse {
+  private readonly _response: any;
+
+  constructor(response: any) {
+    this._response = response;
+  }
+
+  get statusCode(): number {
+    return this._response.status;
+  }
+
+  get headers(): any {
+    return this._response.headers;
+  }
+}
+
+export { HttpClient, HttpResponse };

--- a/lib/tools/HttpClient.ts
+++ b/lib/tools/HttpClient.ts
@@ -1,8 +1,16 @@
 import axios from 'axios';
 
 class HttpClient {
+  private _headers: any;
+
+  set headers(value: any) {
+    this._headers = value;
+  }
+
   async head(url: string): Promise<HttpResponse> {
-    const response = await axios.head(url);
+    let config;
+    if (this._headers) config = { headers: this._headers };
+    const response = config ? await axios.head(url, config) : await axios.head(url);
     return new HttpResponse(response);
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "prebuild": "node -p \"'export const LIB_VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > lib/version.ts",
     "build": "tsc",
     "dist": "rm -rf dist && npm run build && cp -R build dist && pkg . --output dist/image-url-checker",
-    "format": "prettier --config .prettierrc --check 'lib/**/*.ts'",
+    "format": "prettier --config .prettierrc --write 'lib/**/*.ts'",
     "preversion": "./scripts/preversion.sh && npm run build && npm test",
     "version": "npm run dist && git add -A dist lib/version.ts",
     "postversion": "git push && git push --tags",

--- a/test/analyzing/Analyzer.test.ts
+++ b/test/analyzing/Analyzer.test.ts
@@ -1,9 +1,14 @@
+import axios from 'axios';
 import { OptionValues } from 'commander';
 import Analyzer from '../../lib/analyzing/Analyzer';
 import Line from '../../lib/parsing/Line';
 import AnalyzedLine from '../../lib/analyzing/AnalyzedLine';
 import { logger } from '../../lib/tools/Logger';
 import { HttpClient, HttpResponse } from '../../lib/tools/HttpClient';
+
+jest.mock('axios');
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 class TestingHttpClient extends HttpClient {
 
@@ -160,6 +165,23 @@ describe('#_analyzeSingleLine', () => {
       expect(actual.error).toBe('HTTP_ERROR');
     });
   });
+
+  describe('when headers are defined', () => {
+
+    it('should make an HTTP request with given headers', async () => {
+      // given
+      const headers = {'Authorization': 'bearer some.jwt.token'};
+      analyzer = new Analyzer({headers});
+      const line = new Line(1, 'rec_1;http://image.url', ';');
+
+      // when
+      await analyzer._analyzeSingleLine(line, analyzedLines);
+
+      // then
+      expect(mockedAxios.head).toHaveBeenCalledWith('http://image.url', {headers});
+    });
+  });
+
 });
 
 describe('#analyze', () => {

--- a/test/tools/HttpClient.test.ts
+++ b/test/tools/HttpClient.test.ts
@@ -1,0 +1,47 @@
+import axios from 'axios';
+import { HttpClient, HttpResponse } from '../../lib/tools/HttpClient';
+
+jest.mock('axios');
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('#head', () => {
+
+  it('should call Axios', async () => {
+    // given
+    const httpClient = new HttpClient();
+    const url = 'http://some.url';
+    mockedAxios.head.mockResolvedValueOnce({});
+
+    // when
+    await httpClient.head(url);
+
+    // then
+    expect(axios.head).toHaveBeenCalledWith(url);
+  });
+
+  it('should return an HttpResponse object', async () => {
+    // given
+    const httpClient = new HttpClient();
+    const url = 'http://some.url';
+    mockedAxios.head.mockResolvedValueOnce({
+      data: null,
+      status: 200,
+      statusText: 'OK',
+      headers: {
+        'content-length': 6553,
+        'content-type': 'image/jpeg',
+      },
+      config: {}
+    });
+
+    // when
+    const response = await httpClient.head(url);
+
+    // then
+    expect(response).toBeInstanceOf(HttpResponse);
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['content-length']).toBe(6553);
+    expect(response.headers['content-type']).toBe('image/jpeg');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    // "sourceMap": false,                    /* Generates corresponding '.map' file. */
+    "sourceMap": true,                    /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     "outDir": "build",                        /* Redirect output structure to the directory. */
     "rootDir": "lib",                         /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */


### PR DESCRIPTION
### Context

Some remote servers require HTTP headers (such as `Authorization` for authenticated resources). 

### Engineering

This PR aims to support HTTP request headers with option `-H, --headers <headers...>`.
