### PR TITLE
Configure the output separator for csv

### DIFF
--- a/lib/reporting/CsvFileReporter.ts
+++ b/lib/reporting/CsvFileReporter.ts
@@ -6,10 +6,12 @@ import { AbstractReporter } from './Reporter';
 
 export default class CsvFileReporter extends AbstractReporter {
   output?: PathLike;
+  separator: string;
 
   constructor(options: OptionValues) {
     super(options);
     this.output = options.output;
+    this.separator = options.separator || ';';
   }
 
   writeOutputLines(analyzedLines: AnalyzedLine[]): Promise<void> {
@@ -20,9 +22,9 @@ export default class CsvFileReporter extends AbstractReporter {
       outputStream.on('finish', resolve);
 
       analyzedLines.forEach((line) => {
-        outputStream.write(`${line.reference};${line.url};${line.status}`);
+        outputStream.write([line.reference, line.url, line.status].join(this.separator));
         if (line.error) {
-          outputStream.write(`;${line.error};`);
+          outputStream.write(`${this.separator}${line.error}${this.separator}`);
           line.comments.forEach((comment) => outputStream.write(`${comment}`));
         }
         outputStream.write('\n');

--- a/test/reporting/CsvFileReporter.test.ts
+++ b/test/reporting/CsvFileReporter.test.ts
@@ -15,6 +15,28 @@ describe('Constructor', () => {
     // then
     expect(reporter.output).toBe('test_output.csv');
   });
+
+  test('should set ";" as default separator', () => {
+    // given
+    const options = {};
+
+    // when
+    const reporter = new CsvFileReporter(options);
+
+    // then
+    expect(reporter.separator).toBe(';');
+  });
+
+  test('should use given separator', () => {
+    // given
+    const options = {separator: ','};
+
+    // when
+    const reporter = new CsvFileReporter(options);
+
+    // then
+    expect(reporter.separator).toBe(',');
+  });
 });
 
 describe('#report', () => {


### PR DESCRIPTION
I use a "real" csv as an input use the comma separator. The output csv was not reusing the separator option from the command line. So I added support to it.