### PR TITLE
Add more details of the error when catching exceptions

### DIFF
--- a/lib/analyzing/Analyzer.ts
+++ b/lib/analyzing/Analyzer.ts
@@ -75,8 +75,8 @@ export default class Analyzer {
             'HTTP status is not 200(OK) or the response content type is not an image'
           );
         }
-      } catch (err) {
-        analyzedLine.markInError('HTTP_ERROR', 'Unreachable HTTP resource');
+      } catch (err: any) {
+        analyzedLine.markInError('HTTP_ERROR', err.message);
       } finally {
         if (this.delay) {
           await this._sleep(this.delay);


### PR DESCRIPTION
The current message when there is an http exception is not really descriptive.

I added the message of the exception to the output.